### PR TITLE
Limit ci workflow permission to read

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/xijinping0/books/security/code-scanning/1](https://github.com/xijinping0/books/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient, as the workflow only needs to read the repository's contents to perform CI tasks.

The `permissions` block will be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
